### PR TITLE
Add a clean logout with Keycloak

### DIFF
--- a/src/HybridAuthLoginExtension.php
+++ b/src/HybridAuthLoginExtension.php
@@ -326,7 +326,7 @@ class HybridAuthLoginExtension extends AbstractLoginFSMExtension implements iLog
 		$loginMode = Session::Get('login_mode');
 	  if ($loginMode === 'hybridauth-Keycloak')
 	  {
-			// Allow a clean logout with Keycloak 
+		  // Allow a clean logout with Keycloak 
 	    $oAuthAdapter = self::ConnectHybridAuth();
 	    $providers = Config::Get('providers');
 
@@ -342,7 +342,7 @@ class HybridAuthLoginExtension extends AbstractLoginFSMExtension implements iLog
 
 	    // Redirection to Keycloak
 	    header("Location: $logoutUrl");
-	  }
+	  } 
 	  else if (utils::StartsWith($loginMode, 'hybridauth-'))
 	  {
 	    $oAuthAdapter = self::ConnectHybridAuth();


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | <!-- Put the URL -->
| Type of change?                                               | Enhancement 


## Symptom (bug) / Objective (enhancement)
When authentication to iTop is done with Keycloak, at the logout, the session at Keycloak's level is not released.

## Proposed solution (bug and enhancement)
In specific case of login mode with "hybridauth-Keycloak", retrieve keycloak parameters from configuration's file and send a logout to end the keycloak session and update the url redirection attribut.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance (release 3.2.0) and with Keycloak release 25.0.0
- [ ] Would a unit test be relevant and have I added it? => Unable to run the unit tests from this repo alone.
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
